### PR TITLE
Add back express-formidable

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,13 @@ const mongo = new mongodb.MongoClient(process.env.DB_ADDRESS, {
 })
 const http = require('http').createServer(app)
 
-app.use(formidable({ maxFileSize: 5 * 1024 * 1024, maxFieldsSize: 16 * 1024 * 1024, multiples: true }));
+app.use(
+  formidable({
+    maxFileSize: 5 * 1024 * 1024,
+    maxFieldsSize: 16 * 1024 * 1024,
+    multiples: true,
+  })
+)
 app.use(cors())
 
 app.set('trust proxy', true)

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@
 
 require('dotenv').config()
 const app = require('express')()
+const formidable = require('express-formidable')
 const cors = require('cors')
 const argon2 = require('argon2')
 const WebSocket = require('ws')
@@ -31,6 +32,7 @@ const mongo = new mongodb.MongoClient(process.env.DB_ADDRESS, {
 })
 const http = require('http').createServer(app)
 
+app.use(formidable({ maxFileSize: 5 * 1024 * 1024, maxFieldsSize: 16 * 1024 * 1024, multiples: true }));
 app.use(cors())
 
 app.set('trust proxy', true)
@@ -47,8 +49,8 @@ http.listen(8080, async () => {
       : null
     if (session != null) return res.status(401).json(returnCode(401, 1))
 
-    let username = req.fields.username
-    let password = req.fields.password
+    let username = req.fields?.username
+    let password = req.fields?.password
     if (username == null || password == null)
       return res.status(401).json(returnCode(401, 2))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-formidable": "^1.2.0",
         "helmet": "^7.0.0",
         "http": "^0.0.1-security",
         "mongodb": "^5.6.0",
@@ -913,6 +914,17 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-formidable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-formidable/-/express-formidable-1.2.0.tgz",
+      "integrity": "sha512-w1vXjF3gb50UKTNkFaW8/4rqY4dUrKfZ1sAZzwAF9YxCAgj/29QZsycf71di0GkskrZOAkubk9pvGYfxyAMYiw==",
+      "dependencies": {
+        "formidable": "^1.0.17"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1003,6 +1015,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -6114,6 +6135,14 @@
         "vary": "~1.1.2"
       }
     },
+    "express-formidable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-formidable/-/express-formidable-1.2.0.tgz",
+      "integrity": "sha512-w1vXjF3gb50UKTNkFaW8/4rqY4dUrKfZ1sAZzwAF9YxCAgj/29QZsycf71di0GkskrZOAkubk9pvGYfxyAMYiw==",
+      "requires": {
+        "formidable": "^1.0.17"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6189,6 +6218,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ=="
     },
     "forwarded": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-formidable": "^1.2.0",
     "helmet": "^7.0.0",
     "http": "^0.0.1-security",
     "mongodb": "^5.6.0",


### PR DESCRIPTION
Adds the `express-formidable` back to the project as it is *actually* an important dependency which *actually* was the cause why fields and such work.

oops...